### PR TITLE
Use batch script to call upload related commands

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,11 +5,13 @@ environment:
 build_script:
   - pip install cibuildwheel==0.2.0
   - cibuildwheel --output-dir wheelhouse
-  - ps: >-
-      if ($env:APPVEYOR_REPO_TAG -eq "true") {
-        python -m pip install twine
-        python -m twine upload (resolve-path wheelhouse\*.whl)
-      }
+  - >
+    IF "%APPVEYOR_REPO_TAG%" == "true"
+    (
+    python -m pip install twine
+    &&
+    python -m twine upload wheelhouse/*.whl
+    )
 artifacts:
   - path: "wheelhouse\\*.whl"
     name: Wheels


### PR DESCRIPTION
PowerShell usage resulted on a failed build because of the way it handles external tools.
Use a batch script instead.

Fixes joerick/cibuildwheel-autopypi-example#1