### PR TITLE
DO NOT MERGE: Add a setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,5 @@ setup(
     name="cibuildwheel_autopypi_example",
     ext_modules=[Extension('cibuildwheel_autopypi_example', sources=['cibuildwheel_autopypi_example.c'])],
     version="0.1.14",
+    setup_requires=['py'],
 )


### PR DESCRIPTION
This will probably error on macOS Python 3.6 with something like:

```
+ pip3 wheel . -w /tmp/built_wheel --no-deps
Processing /Users/travis/build/foo/bar
    Complete output from command python setup.py egg_info:
    Download error on https://pypi.python.org/simple/py/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:749) -- Some packages may not be found!
    Couldn't find index page for 'py' (maybe misspelled?)
    Download error on https://pypi.python.org/simple/: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:749) -- Some packages may not be found!
    No local packages or working download links found for py
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/my/m6ynh3bn6tq06h7xr3js0z7r0000gn/T/pip-9lqeq18p-build/setup.py", line 45, in <module>
        'Topic :: Multimedia :: Graphics :: 3D Modeling',
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/distutils/core.py", line 108, in setup
        _setup_distribution = dist = klass(attrs)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/setuptools/dist.py", line 315, in __init__
        self.fetch_build_eggs(attrs['setup_requires'])
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/setuptools/dist.py", line 361, in fetch_build_eggs
        replace_conflicting=True,
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/__init__.py", line 850, in resolve
        dist = best[req.key] = env.best_match(req, ws, installer)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1122, in best_match
        return self.obtain(req, installer)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/pkg_resources/__init__.py", line 1134, in obtain
        return installer(requirement)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/setuptools/dist.py", line 429, in fetch_build_egg
        return cmd.easy_install(req)
      File "/Library/Frameworks/Python.framework/Versions/3.6/lib/python3.6/site-packages/setuptools/command/easy_install.py", line 659, in easy_install
        raise DistutilsError(msg)
    distutils.errors.DistutilsError: Could not find suitable distribution for Requirement.parse('py')
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/my/m6ynh3bn6tq06h7xr3js0z7r0000gn/T/pip-9lqeq18p-build/
Traceback (most recent call last):
  File "/usr/local/bin/cibuildwheel", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python2.7/site-packages/cibuildwheel/__main__.py", line 135, in main
    cibuildwheel.macos.build(**build_options)
  File "/usr/local/lib/python2.7/site-packages/cibuildwheel/macos.py", line 75, in build
    call([pip, 'wheel', project_dir, '-w', '/tmp/built_wheel', '--no-deps'], env=env)
  File "/usr/local/lib/python2.7/site-packages/cibuildwheel/macos.py", line 29, in call
    return subprocess.check_call(args, env=env, cwd=cwd, shell=shell)
  File "/usr/local/Cellar/python/2.7.12_1/Frameworks/Python.framework/Versions/2.7/lib/python2.7/subprocess.py", line 541, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['pip3', 'wheel', '.', '-w', '/tmp/built_wheel', '--no-deps']' returned non-zero exit status 1
```

Just checking if it actually will.